### PR TITLE
Fixes curl-Downloads not showing and internal server error

### DIFF
--- a/controller/lib/api.php
+++ b/controller/lib/api.php
@@ -165,6 +165,7 @@ class API
             $Query = \OCP\DB::prepare($SQL);
             $Request = $Query->execute($Params);
             
+			$DownloadUpdated = false;
             $Queue = [];
             
             while ($Row = $Request->fetchRow()) {
@@ -224,6 +225,8 @@ class API
                                     SET "STATUS" = ? WHERE "UID" = ? AND "GID" = ? AND "STATUS" != ?';
                             }
                             
+							$DownloadUpdated = true;
+							
                             $Query = \OCP\DB::prepare($SQL);
                             $Result = $Query->execute(array(
                                 $DLStatus,
@@ -279,6 +282,12 @@ class API
                     );
                 }
             }
+			
+			// Start rescan on update
+			if ($DownloadUpdated) {
+				Tools::rescanFolder(\OC\Files\Filesystem::getRoot() . self::$DownloadsFolder);
+			}
+			
             return array(
                 'ERROR' => false,
                 'MESSAGE' => null,

--- a/controller/lib/curl.php
+++ b/controller/lib/curl.php
@@ -82,7 +82,7 @@ class CURL
     {
         $Return = null;
         if (isset($Status['PID']) && is_numeric($Status['PID']) && isset($Status['GID'])) {
-            if (posix_kill($Status['PID'], 15) === false) {
+            if ($Status['PID'] == 0 || posix_kill($Status['PID'], 15) === false) {
                 $Return = null;
             }
             

--- a/controller/lib/tools.php
+++ b/controller/lib/tools.php
@@ -238,4 +238,19 @@ class Tools
     {
         return mb_strlen($filename, "UTF-8") > 40 ? mb_substr($filename, 0, 40, "UTF-8") . '...' : $filename;
     }
+	
+	public static function rescanFolder($Folder)
+	{
+		$PHPVersions = array('php71', 'php70', 'php56');
+		foreach($PHPVersions as $Version)
+		{
+			$FullPath = shell_exec('which ' . $Version);
+			$FullPath = trim($FullPath);
+			if (!empty($FullPath))
+			{
+				shell_exec($FullPath . ' ' . __DIR__ . '/../../../../occ files:scan --path "' . $Folder . '"');
+				break;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Added rescan when a download is finished. Fixes #19 and should also fix #31 (not tested).
posix_kill throws a non-catchable internal server error if the PID is 0. Changed to call that function only on PID > 0.