### PR TITLE
Quota constraint

### DIFF
--- a/controller/ftpdownloader.php
+++ b/controller/ftpdownloader.php
@@ -21,6 +21,7 @@ use OCA\ocDownloader\Controller\Lib\Aria2;
 use OCA\ocDownloader\Controller\Lib\CURL;
 use OCA\ocDownloader\Controller\Lib\Tools;
 use OCA\ocDownloader\Controller\Lib\Settings;
+use OCA\ocDownloader\Controller\Lib\QuotaManager;
 
 class FtpDownloader extends Controller
 {
@@ -134,6 +135,15 @@ class FtpDownloader extends Controller
                 }
                 if (!is_null($this->MaxDownloadSpeed) && $this->MaxDownloadSpeed > 0) {
                     $OPTIONS['max-download-limit'] = $this->MaxDownloadSpeed . 'K';
+                }
+
+                if(!QuotaManager::allowedByQuota($_POST['FILE'])) {
+                    return new JSONResponse(
+                        array(
+                            'ERROR' => true,
+                            'MESSAGE' => (string)$this->L10N->t("Not enough free space")
+                        )
+                    );
                 }
 
                 $AddURI =(

--- a/controller/httpdownloader.php
+++ b/controller/httpdownloader.php
@@ -21,6 +21,7 @@ use OCA\ocDownloader\Controller\Lib\Aria2;
 use OCA\ocDownloader\Controller\Lib\CURL;
 use OCA\ocDownloader\Controller\Lib\Tools;
 use OCA\ocDownloader\Controller\Lib\Settings;
+use OCA\ocDownloader\Controller\Lib\QuotaManager;
 
 class HttpDownloader extends Controller
 {
@@ -136,6 +137,15 @@ class HttpDownloader extends Controller
                     }
                     if (!is_null($this->MaxDownloadSpeed) && $this->MaxDownloadSpeed > 0) {
                         $OPTIONS['max-download-limit'] = $this->MaxDownloadSpeed . 'K';
+                    }
+
+                    if(!QuotaManager::allowedByQuota($_POST['FILE'])) {
+                        return new JSONResponse(
+                            array(
+                                'ERROR' => true,
+                                'MESSAGE' => (string)$this->L10N->t("Not enough free space")
+                            )
+                        );
                     }
 
                     $AddURI = (

--- a/controller/lib/quotamanager.php
+++ b/controller/lib/quotamanager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OCA\ocDownloader\Controller\Lib;
+
+
+class QuotaManager
+{
+    //Amount of space for downloading files
+    private static $ReservedSpace = 0;
+
+    /**
+     * @param $URI
+     * @return bool
+     */
+    public static function allowedByQuota($URI)
+    {
+        $SessionUID = \OC::$server->getUserSession()->getUser();
+        $HomeDir = $SessionUID->getHome();
+        $FreeSpace = \OC\Files\Filesystem::free_space($HomeDir);
+
+        $FileSize = self::getSize($URI);
+
+        return ($FileSize > $FreeSpace)? false : true;
+    }
+
+    /**
+     * @param $URI
+     * @return int|mixed, -1 if error
+     */
+    private static function getSize($URI)
+    {
+        $Handle = curl_init($URI);
+
+        curl_setopt($Handle, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($Handle, CURLOPT_HEADER, TRUE);
+        curl_setopt($Handle, CURLOPT_NOBODY, TRUE);
+
+        $FileSize = -1;
+        if (curl_exec($Handle) != false) {
+            $FileSize = curl_getinfo($Handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
+        }
+
+        curl_close($Handle);
+        return $FileSize;
+    }
+}


### PR DESCRIPTION
It checks if current file is bigger than free space. It should work for HTTP and FTP for both cURL and Aria2.
What I haven't done yet:
- "Not enough free space" wasn't translated. As nextcloud/server have exactly the same string, it'll be easy to translate.
- If you start two or more downloads at the same time, quota might be exceeded. I plan to work on it.
- In case of error (when it's impossible to define size), it allows to download. To be sure what to do it requires many tests.