### PR TITLE
fixed error when downloading with curl failed in alpine

### DIFF
--- a/SERVER/fallback.sh
+++ b/SERVER/fallback.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=$( cd "$( dirname "$0" )" && pwd )
 $(which nohup) $(which php) $DIR/fallback.php "$1" "$2" "$3" > /tmp/nohup.out 2>&1 &

--- a/controller/lib/curl.php
+++ b/controller/lib/curl.php
@@ -114,7 +114,7 @@ class CURL
     private static function run()
     {
         shell_exec(
-            rtrim(dirname(__FILE__), '/') . '/../../SERVER/fallback.sh "' . self::$GID . '" "'
+            "sh " . rtrim(dirname(__FILE__), '/') . '/../../SERVER/fallback.sh "' . self::$GID . '" "'
             .urlencode(self::$URI) . '" "' . urlencode(json_encode(self::$OPTIONS, JSON_HEX_APOS | JSON_HEX_QUOT)).'"'
         );
     }


### PR DESCRIPTION
Fixed error:  "sh: /data/wwwroot/nextcloud/apps/ocdownloader/controller/lib/../../SERVER/fallback.sh: not found" in alpine

And you should better run `chmod 777 /tmp/nohup.out` to make sure you have permission of this file.