### PR TITLE
Fix for issue #140

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -11,7 +11,9 @@
 
 use OCA\ocDownloader\Controller\Lib\Settings;
 
-\OC_Util::checkAdminUser();
+if (!OC_User::isAdminUser(OC_User::getUser())) {
+   return;
+}
 
 // Display template
 \OCP\Util::addStyle('ocdownloader', 'settings/admin');


### PR DESCRIPTION
Fix issue with breakage in OC 17-18 due to change of group admin.
See: https://github.com/e-alfred/ocdownloader/issues/140

CheckAdminUser() redirects to /apps/files if a user start settings/user AND is a GroupAdmin for some group AND not a full Admin.
