### PR TITLE
Added support for youtube-dl formats (for audio and video cases)

### DIFF
--- a/controller/adminsettings.php
+++ b/controller/adminsettings.php
@@ -25,7 +25,7 @@ class AdminSettings extends Controller
     private $DbType = 0;
     private $L10N;
     private $OCDSettingKeys = array(
-        'YTDLBinary', 'ProxyAddress', 'ProxyPort', 'ProxyUser', 'ProxyPasswd', 'WhichDownloader',
+        'YTDLBinary', 'YTDLAudioFormat', 'YTDLVideoFormat', 'ProxyAddress', 'ProxyPort', 'ProxyUser', 'ProxyPasswd', 'WhichDownloader',
         'ProxyOnlyWithYTDL', 'AllowProtocolHTTP', 'AllowProtocolFTP', 'AllowProtocolYT', 'AllowProtocolBT',
         'MaxDownloadSpeed', 'BTMaxUploadSpeed'
     );
@@ -71,6 +71,8 @@ class AdminSettings extends Controller
                             $Error = true;
                             $Message =(string)$this->L10N->t('Unable to find YouTube-DL binary');
                         }
+                    } elseif (strcmp($PostKey, 'YTDLAudioFormat') == 0) {
+                    } elseif (strcmp($PostKey, 'YTDLVideoFormat') == 0) {
                     } elseif (strcmp($PostKey, 'ProxyAddress') == 0) {
                         if (!Tools::checkURL($PostValue) && strlen(trim($PostValue)) > 0) {
                             $PostValue = null;
@@ -173,6 +175,12 @@ class AdminSettings extends Controller
                     switch ($PostKey) {
                         case 'YTDLBinary':
                             $AdminSettings[$PostKey] = '/usr/local/bin/youtube-dl';
+                            break;
+                        case 'YTDLAudioFormat':
+                            $AdminSettings[$PostKey] = 'bestaudio';
+                            break;
+                        case 'YTDLVideoFormat':
+                            $AdminSettings[$PostKey] = 'best';
                             break;
                         case 'CheckForUpdates':
                             $AdminSettings[$PostKey] = 'Y';

--- a/controller/lib/api.php
+++ b/controller/lib/api.php
@@ -28,6 +28,8 @@ class API extends Controller
     private static $DownloadsFolder = null;
     private static $DbType = 0;
     private static $YTDLBinary = null;
+    private static $YTDLAudioFormat = null;
+    private static $YTDLVideoFormat = null;
     private static $ProxyAddress = null;
     private static $ProxyPort = 0;
     private static $ProxyUser = null;
@@ -53,9 +55,25 @@ class API extends Controller
          $Settings->setKey('YTDLBinary');
          $YTDLBinary = $Settings->getValue();
 
+         $Settings->setKey('YTDLAudioFormat');
+         $YTDLAudioFormat = $Settings->getValue();
+
+         $Settings->setKey('YTDLVideoFormat');
+         $YTDLVideoFormat = $Settings->getValue();
+
          $this->YTDLBinary = '/usr/local/bin/youtube-dl'; // default path
          if (!is_null($YTDLBinary)) {
             $this->YTDLBinary = $YTDLBinary;
+         }
+
+         $this->YTDLAudioFormat = 'bestaudio'; // default setting
+         if (!is_null($YTDLAudioFormat)) {
+            $this->YTDLAudioFormat = $YTDLAudioFormat;
+         }
+         
+         $this->YTDLVideoFormat = 'best'; // default setting
+         if (!is_null($YTDLVideoFormat)) {
+            $this->YTDLVideoFormat = $YTDLVideoFormat;
          }
       }
 
@@ -76,7 +94,7 @@ class API extends Controller
                         return array('ERROR' => true, 'MESSAGE' => 'Notallowedtouseprotocolyt');
                     }
 
-                    $YouTube = new YouTube(self::$YTDLBinary, $URL);
+                    $YouTube = new YouTube(self::$YTDLBinary, $URL, self::$YTDLAudioFormat, self::$YTDLVideoFormat);
 
                     if (!is_null(self::$ProxyAddress) && self::$ProxyPort > 0 && self::$ProxyPort <= 65536) {
                         $YouTube->setProxy(self::$ProxyAddress, self::$ProxyPort);
@@ -426,6 +444,22 @@ class API extends Controller
         self::$YTDLBinary = '/usr/local/bin/youtube-dl'; // default path
         if (!is_null($YTDLBinary)) {
             self::$YTDLBinary = $YTDLBinary;
+        }
+
+        $Settings->setKey('YTDLAudioFormat');
+        $YTDLAudioFormat = $Settings->getValue();
+
+        self::$YTDLAudioFormat = 'bestaudio'; // default path
+        if (!is_null($YTDLAudioFormat)) {
+            self::$YTDLAudioFormat = $YTDLAudioFormat;
+        }
+
+        $Settings->setKey('YTDLVideoFormat');
+        $YTDLVideoFormat = $Settings->getValue();
+
+        self::$YTDLVideoFormat = 'best'; // default path
+        if (!is_null($YTDLVideoFormat)) {
+            self::$YTDLVideoFormat = $YTDLVideoFormat;
         }
     }
 }

--- a/controller/lib/youtube.php
+++ b/controller/lib/youtube.php
@@ -14,14 +14,18 @@ namespace OCA\ocDownloader\Controller\Lib;
 class YouTube
 {
     private $YTDLBinary = null;
+    private $YTDLAudioFormat = null;
+    private $YTDLVideoFormat = null;
     private $URL = null;
     private $ForceIPv4 = true;
     private $ProxyAddress = null;
     private $ProxyPort = 0;
 
-    public function __construct($YTDLBinary, $URL)
+    public function __construct($YTDLBinary, $URL, $YTDLAudioFormat, $YTDLVideoFormat)
     {
         $this->YTDLBinary = $YTDLBinary;
+        $this->YTDLAudioFormat = $YTDLAudioFormat;
+        $this->YTDLVideoFormat = $YTDLVideoFormat;
         $this->URL = $URL;
     }
 
@@ -46,10 +50,12 @@ class YouTube
 
         //youtube multibyte support
         putenv('LANG=en_US.UTF-8');
-
+        
+        $fAudio = escapeshellarg($this->YTDLAudioFormat);
+        $fVideo = escapeshellarg($this->YTDLVideoFormat);
         $Output = shell_exec(
             $this->YTDLBinary.' -i \''.$this->URL.'\' --get-url --get-filename'
-            .($ExtractAudio?' -f bestaudio -x':' -f best').($this->ForceIPv4 ? ' -4' : '')
+            .($ExtractAudio?" -f $fAudio -x":" -f $fVideo").($this->ForceIPv4 ? ' -4' : '')
             .(is_null($Proxy) ? '' : $Proxy)
         );
 

--- a/controller/ytdownloader.php
+++ b/controller/ytdownloader.php
@@ -29,6 +29,8 @@ class YTDownloader extends Controller
     private $DownloadsFolder = null;
     private $DbType = 0;
     private $YTDLBinary = null;
+    private $YTDLAudioFormat = null;
+    private $YTDLVideoFormat = null;
     private $ProxyAddress = null;
     private $ProxyPort = 0;
     private $ProxyUser = null;
@@ -54,9 +56,25 @@ class YTDownloader extends Controller
         $Settings->setKey('YTDLBinary');
         $YTDLBinary = $Settings->getValue();
 
-        $this->YTDLBinary = '/usr/local/bin/youtube-dl'; // default path
+        $this->YTDLBinary = '/usr/bin/youtube-dl'; // default path
         if (!is_null($YTDLBinary)) {
             $this->YTDLBinary = $YTDLBinary;
+        }
+
+        $Settings->setKey('YTDLAudioFormat');
+        $YTDLAudioFormat = $Settings->getValue();
+
+        $this->YTDLAudioFormat = 'bestaudio'; // default path
+        if (!is_null($YTDLAudioFormat)) {
+            $this->YTDLAudioFormat = $YTDLAudioFormat;
+        }
+
+        $Settings->setKey('YTDLVideoFormat');
+        $YTDLVideoFormat = $Settings->getValue();
+
+        $this->YTDLVideoFormat = 'best'; // default path
+        if (!is_null($YTDLVideoFormat)) {
+            $this->YTDLVideoFormat = $YTDLVideoFormat;
         }
 
         $Settings->setKey('ProxyAddress');
@@ -102,7 +120,7 @@ class YTDownloader extends Controller
                     throw new \Exception((string)$this->L10N->t('You are not allowed to use the YouTube protocol'));
                 }
 
-                $YouTube = new YouTube($this->YTDLBinary, $_POST['FILE']);
+                $YouTube = new YouTube($this->YTDLBinary, $_POST['FILE'], $this->YTDLAudioFormat, $this->YTDLVideoFormat);
 
                 if (!is_null($this->ProxyAddress) && $this->ProxyPort > 0 && $this->ProxyPort <= 65536) {
                     $YouTube->SetProxy($this->ProxyAddress, $this->ProxyPort);

--- a/css/settings/admin.css
+++ b/css/settings/admin.css
@@ -16,6 +16,12 @@ form#ocdownloader span.msg {
 form#ocdownloader input.OCDYTDLBinary {
 	width: 400px;
 }
+form#ocdownloader input.OCDYTDLAudioFormat {
+	width: 400px;
+}
+form#ocdownloader input.OCDYTDLVideoFormat {
+	width: 400px;
+}
 form#ocdownloader input.OCDProxyAddress {
 	width: 270px;
 }

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -19,6 +19,14 @@
 		<label for="OCDYTDLBinary"><?php print ($l->t ('YouTube DL Binary Path')); ?></label>
 		<input type="text" class="OCDYTDLBinary ToUse" id="OCDYTDLBinary" data-loader="OCDSLoaderYTDLBinary" value="<?php print (isset ($_['OCDS_YTDLBinary']) ? $_['OCDS_YTDLBinary'] : '/usr/local/bin/youtube-dl'); ?>" />
 	</p>
+	<p>
+		<label for="OCDYTDLAudoFormat"><?php print ($l->t ('YouTube DL Audio Format')); ?></label>
+		<input type="text" class="OCDYTDLAudioFormat ToUse" id="OCDYTDLAudioFormat" data-loader="OCDSLoaderYTDLAudioFormat" value="<?php print (isset ($_['OCDS_YTDLAudioFormat']) ? $_['OCDS_YTDLAudioFormat'] : 'bestaudio'); ?>" />
+	</p>
+	<p>
+		<label for="OCDYTDLAudoFormat"><?php print ($l->t ('YouTube DL Video Format')); ?></label>
+		<input type="text" class="OCDYTDLVideoFormat ToUse" id="OCDYTDLVideoFormat" data-loader="OCDSLoaderYTDLVideoFormat" value="<?php print (isset ($_['OCDS_YTDLVideoFormat']) ? $_['OCDS_YTDLVideoFormat'] : 'best'); ?>" />
+	</p>
 	<hr />
 	<div style="clear:both;"></div>
 	<p>


### PR DESCRIPTION
I've added support for specifying `-f` format for youtube-dl. Changes are made in the same manner as configuration of youtube-dl binary, i.e. they are system-wide.

Sensible presets for me are `YTDLAudioFormat = "bestaudio[abr<=75]"`, `YTDLVideoFormat = "best[width<=1280]"`.

Not sure if it is good to pass these arguments via YouTube() constructor, maybe it would be better to have getters/setters for it.