### PR TITLE
Support for remote Aria2.

### DIFF
--- a/controller/adminsettings.php
+++ b/controller/adminsettings.php
@@ -27,7 +27,7 @@ class AdminSettings extends Controller
     private $OCDSettingKeys = array(
         'YTDLBinary', 'YTDLAudioFormat', 'YTDLVideoFormat', 'ProxyAddress', 'ProxyPort', 'ProxyUser', 'ProxyPasswd', 'WhichDownloader',
         'ProxyOnlyWithYTDL', 'AllowProtocolHTTP', 'AllowProtocolFTP', 'AllowProtocolYT', 'AllowProtocolBT',
-        'MaxDownloadSpeed', 'BTMaxUploadSpeed', 'AriaAddress', 'AriaPort'
+        'MaxDownloadSpeed', 'BTMaxUploadSpeed', 'AriaAddress', 'AriaPort', 'AriaToken'
     );
     private $Settings = null;
 
@@ -113,6 +113,8 @@ class AdminSettings extends Controller
                             $Error = true;
                             $Message =(string)$this->L10N->t('Aria port should be a value from 1 to 65536');
                         }
+                    } elseif (strcmp($PostKey, 'AriaToken') == 0) {
+                        $Error = false;
                     } elseif (strcmp($PostKey, 'WhichDownloader') == 0) {
                         if (!in_array($PostValue, array('ARIA2', 'CURL'))) {
                             $PostValue = 'ARIA2';

--- a/controller/adminsettings.php
+++ b/controller/adminsettings.php
@@ -27,7 +27,7 @@ class AdminSettings extends Controller
     private $OCDSettingKeys = array(
         'YTDLBinary', 'YTDLAudioFormat', 'YTDLVideoFormat', 'ProxyAddress', 'ProxyPort', 'ProxyUser', 'ProxyPasswd', 'WhichDownloader',
         'ProxyOnlyWithYTDL', 'AllowProtocolHTTP', 'AllowProtocolFTP', 'AllowProtocolYT', 'AllowProtocolBT',
-        'MaxDownloadSpeed', 'BTMaxUploadSpeed'
+        'MaxDownloadSpeed', 'BTMaxUploadSpeed', 'AriaAddress', 'AriaPort'
     );
     private $Settings = null;
 
@@ -96,6 +96,22 @@ class AdminSettings extends Controller
                     } elseif (strcmp($PostKey, 'CheckForUpdates') == 0) {
                         if (!in_array($PostValue, array('Y', 'N'))) {
                             $PostValue = 'Y';
+                        }
+                    } elseif (strcmp($PostKey, 'AriaAddress') == 0) {
+                        if (!Tools::checkURL($PostValue) && strlen(trim($PostValue)) > 0) {
+                            $PostValue = null;
+                            $Error = true;
+                            $Message =(string)$this->L10N->t('Invalid Aria address URL');
+                        }
+                    } elseif (strcmp($PostKey, 'AriaPort') == 0) {
+                        if (!is_numeric($PostValue)) {
+                            $PostValue = null;
+                            $Error = true;
+                            $Message =(string)$this->L10N->t('Aria port should be a numeric value');
+                        } elseif ($PostValue <= 0 || $PostValue > 65536) {
+                            $PostValue = null;
+                            $Error = true;
+                            $Message =(string)$this->L10N->t('Aria port should be a value from 1 to 65536');
                         }
                     } elseif (strcmp($PostKey, 'WhichDownloader') == 0) {
                         if (!in_array($PostValue, array('ARIA2', 'CURL'))) {

--- a/controller/lib/aria2.php
+++ b/controller/lib/aria2.php
@@ -15,6 +15,7 @@ use \OCA\ocDownloader\Controller\Lib\Settings;
 class Aria2
 {
     private static $Server = null;
+    private static $Token = null;
     private static $CurlHandler;
     
     public static function __callStatic($Name, $Args)
@@ -28,6 +29,14 @@ class Aria2
         self::$Server .= '/jsonrpc';
 
         $Args =(strcmp($Name, 'addTorrent') == 0 ? self::rebuildTorrentArgs($Args) : self::rebuildArgs($Args));
+
+        $Settings->setKey('AriaToken');
+        self::$Token = $Settings->getValue();
+
+        if (!empty(self::$Token)) {
+            self::$Token = 'token:' . self::$Token;
+            array_unshift($Args, self::$Token);
+        }
       
         self::load();
       

--- a/controller/lib/aria2.php
+++ b/controller/lib/aria2.php
@@ -10,6 +10,8 @@
  */
 namespace OCA\ocDownloader\Controller\Lib;
 
+use \OCA\ocDownloader\Controller\Lib\Settings;
+
 class Aria2
 {
     private static $Server = null;
@@ -17,7 +19,14 @@ class Aria2
     
     public static function __callStatic($Name, $Args)
     {
-        self::$Server = 'http://127.0.0.1:6800/jsonrpc';
+        $Settings = new Settings();
+        $Settings->setKey('AriaAddress');
+        self::$Server = $Settings->getValue() ? $Settings->getValue() : '127.0.0.1';
+        self::$Server .= ':';
+        $Settings->setKey('AriaPort');
+        self::$Server .= $Settings->getValue() ? $Settings->getValue() : '6800';
+        self::$Server .= '/jsonrpc';
+
         $Args =(strcmp($Name, 'addTorrent') == 0 ? self::rebuildTorrentArgs($Args) : self::rebuildArgs($Args));
       
         self::load();

--- a/css/settings/admin.css
+++ b/css/settings/admin.css
@@ -31,6 +31,12 @@ form#ocdownloader input.OCDProxyPort {
 form#ocdownloader input.OCDProxyUserFake, form#ocdownloader > p > input.OCDProxyPasswdFake {
 	display: none;
 }
+form#ocdownloader input.OCDAriaAddress {
+	width: 270px;
+}
+form#ocdownloader input.OCDAriaPort {
+	width: 102px;
+}
 form#ocdownloader span.info {
 	font-style: italic;
 	color: #003366;

--- a/css/settings/admin.css
+++ b/css/settings/admin.css
@@ -31,12 +31,15 @@ form#ocdownloader input.OCDProxyPort {
 form#ocdownloader input.OCDProxyUserFake, form#ocdownloader > p > input.OCDProxyPasswdFake {
 	display: none;
 }
+
 form#ocdownloader input.OCDAriaAddress {
 	width: 270px;
 }
+
 form#ocdownloader input.OCDAriaPort {
 	width: 102px;
 }
+
 form#ocdownloader span.info {
 	font-style: italic;
 	color: #003366;

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -74,6 +74,14 @@
 		</select>
 		<span id="OCDWhichDownloaderDetails" class="details"><?php print ($l->t ('Available protocols') . ': '); ?><strong></strong></span>
 	</p>
+	<div id="OCDBTSettings"<?php print ((isset ($_['OCDS_WhichDownloader']) && strcmp ($_['OCDS_WhichDownloader'], 'ARIA2') == 0) ? '' : ' style="display:none"'); ?>>
+	<p>
+		<label for="OCDAriaAddress"><?php print ($l->t ('ARIA2 Address')); ?></label>
+		<input type="text" class="OCDAriaAddress ToUse" id="OCDAriaAddress" data-loader="OCDSLoaderGeneralSettings" value="<?php print (isset ($_['OCDS_AriaAddress']) ? $_['OCDS_AriaAddress'] : ''); ?>" placeholder="http://127.0.0.1" />
+		<label for="OCDAriaPort"><?php print ($l->t ('ARIA2 Port')); ?></label>
+		<input type="text" class="OCDAriaPort ToUse" id="OCDAriaPort" data-loader="OCDSLoaderGeneralSettings" value="<?php print (isset ($_['OCDS_AriaPort']) ? $_['OCDS_AriaPort'] : ''); ?>" placeholder="6800" />
+	</p>
+	</div>
 	<p>
 		<label for="OCDMaxDownloadSpeed"><?php print ($l->t ('Max download speed ?')); ?></label>
 		<input type="text" id="OCDMaxDownloadSpeed" data-loader="OCDSLoaderGeneralSettings" class="ToUse" value="<?php print (isset ($_['OCDS_MaxDownloadSpeed']) ? $_['OCDS_MaxDownloadSpeed'] : ''); ?>" placeholder="10000" />

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -81,6 +81,10 @@
 		<label for="OCDAriaPort"><?php print ($l->t ('ARIA2 Port')); ?></label>
 		<input type="text" class="OCDAriaPort ToUse" id="OCDAriaPort" data-loader="OCDSLoaderGeneralSettings" value="<?php print (isset ($_['OCDS_AriaPort']) ? $_['OCDS_AriaPort'] : ''); ?>" placeholder="6800" />
 	</p>
+	<p>
+		<label for="OCDAriaToken"><?php print ($l->t ('ARIA2 Secret Token')); ?></label>
+		<input type="password" class="OCDAriaToken ToUse" id="OCDAriaToken" data-loader="OCDSLoaderGeneralSettings" placeholder="<?php print ($l->t ('Secret Token')); ?>" />
+	</p>
 	</div>
 	<p>
 		<label for="OCDMaxDownloadSpeed"><?php print ($l->t ('Max download speed ?')); ?></label>


### PR DESCRIPTION
Added support for remote Aria2.
This is to address Issue #41.
The input fields "ARIA2 Address" and "ARIA2 Port" can be found under
Settings->Administration->Additional Settings.
If any of the fields is blank, its default value will be used.
"ARIA2 Address" defaults to http://127.0.0.1
"ARIA2 Port" defaults to 6800.