### PR TITLE
Changes to work in postgres

### DIFF
--- a/controller/btdownloader.php
+++ b/controller/btdownloader.php
@@ -163,7 +163,7 @@ class BTDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            ("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP") VALUES(?, ?, ?, ?, ?, ?)';
+                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/btdownloader.php
+++ b/controller/btdownloader.php
@@ -163,7 +163,7 @@ class BTDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
+                            (UID, GID, FILENAME, PROTOCOL, STATUS, TIMESTAMP) VALUES(?, ?, ?, ?, ?, ?)';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/ftpdownloader.php
+++ b/controller/ftpdownloader.php
@@ -147,7 +147,7 @@ class FtpDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            ("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP") VALUES(?, ?, ?, ?, ?, ?)';
+                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/ftpdownloader.php
+++ b/controller/ftpdownloader.php
@@ -147,7 +147,7 @@ class FtpDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
+                            (UID, GID, FILENAME, PROTOCOL, STATUS, TIMESTAMP) VALUES(?, ?, ?, ?, ?, ?)';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/httpdownloader.php
+++ b/controller/httpdownloader.php
@@ -149,7 +149,7 @@ class HttpDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                         if ($this->DbType == 1) {
                             $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
+                            (UID, GID, FILENAME, PROTOCOL, STATUS, TIMESTAMP) VALUES(?, ?, ?, ?, ?, ?)';
                         }
 
                         $Query = \OC_DB::prepare($SQL);

--- a/controller/httpdownloader.php
+++ b/controller/httpdownloader.php
@@ -149,7 +149,7 @@ class HttpDownloader extends Controller
                         (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                         if ($this->DbType == 1) {
                             $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            ("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP") VALUES(?, ?, ?, ?, ?, ?)';
+                            (uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
                         }
 
                         $Query = \OC_DB::prepare($SQL);

--- a/controller/index.php
+++ b/controller/index.php
@@ -49,7 +49,7 @@ class Index extends Controller
         $this->Settings = new Settings();
         $this->Settings->setKey('WhichDownloader');
         $this->WhichDownloader = $this->Settings->getValue();
-        $this->WhichDownloader = is_null($this->WhichDownloader) ? 'ARIA2' : $this->WhichDownloader;
+        $this->WhichDownloader = !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2' ? 'ARIA2' : $this->WhichDownloader;
 
         $this->Settings->setKey('AllowProtocolHTTP');
         $this->AllowProtocolHTTP = $this->Settings->getValue();

--- a/controller/lib/api.php
+++ b/controller/lib/api.php
@@ -153,7 +153,7 @@ class API extends Controller
                         VALUES(?, ?, ?, ?, ?, ?, ?)';
                     if (self::$DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            (uid, gid, filename, protocol, is_cleaned, status, timestamp)
+                            (UID, GID, FILENAME, PROTOCOL, IS_CLEANED, STATUS, TIMESTAMP)
                             VALUES(?, ?, ?, ?, ?, ?, ?)';
                     }
 

--- a/controller/lib/api.php
+++ b/controller/lib/api.php
@@ -153,7 +153,7 @@ class API extends Controller
                         VALUES(?, ?, ?, ?, ?, ?, ?)';
                     if (self::$DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                            ("UID", "GID", "FILENAME", "PROTOCOL", "IS_CLEANED", "STATUS", "TIMESTAMP")
+                            (uid, gid, filename, protocol, is_cleaned, status, timestamp)
                             VALUES(?, ?, ?, ?, ?, ?, ?)';
                     }
 
@@ -216,8 +216,8 @@ class API extends Controller
                 .' ORDER BY `TIMESTAMP` ASC';
             if (self::$DbType == 1) {
                 $SQL = 'SELECT * FROM *PREFIX*ocdownloader_queue
-                    WHERE "UID" = ? AND "STATUS" IN '.$StatusReq.' AND "IS_CLEANED" IN '.$IsCleanedReq
-                    .' ORDER BY "TIMESTAMP" ASC';
+                    WHERE uid = ? AND status IN '.$StatusReq.' AND is_cleaned IN '.$IsCleanedReq
+                    .' ORDER BY timestamp ASC';
             }
             $Query = \OC_DB::prepare($SQL);
             $Request = $Query->execute($Params);
@@ -281,7 +281,7 @@ class API extends Controller
 						WHERE `UID` = ? AND `GID` = ?';
                                 if (self::$DbType == 1) {
                                     $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue
-						WHERE "UID" = ? AND "GID" = ?';
+						WHERE uid = ? AND gid = ?';
                                 }
 
                                 $Query = \OC_DB::prepare($SQL);
@@ -297,7 +297,7 @@ class API extends Controller
 							(`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                                         if (self::DbType == 1) {
                                             $addSQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-							("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP") VALUES(?, ?, ?, ?, ?, ?)';
+							(uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
                                         }
                                         $addQuery = \OC_DB::prepare($addSQL);
                                         $addQuery->execute(array(
@@ -316,7 +316,7 @@ class API extends Controller
 		                            SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ? AND `STATUS` != ?';
                                 if (self::$DbType == 1) {
                                     $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-				                                SET "STATUS" = ? WHERE "UID" = ? AND "GID" = ? AND "STATUS" != ?';
+				                                SET status = ? WHERE uid = ? AND gid = ? AND status != ?';
                                 }
 
                                 $Query = \OC_DB::prepare($SQL);

--- a/controller/lib/settings.php
+++ b/controller/lib/settings.php
@@ -53,8 +53,8 @@ class Settings
         $SQL = 'SELECT `VAL` FROM `*PREFIX*ocdownloader_'.$this->Table.'` WHERE `KEY` = ?'
             .(!is_null($this->UID) ? ' AND `UID` = ?' : '') . ' LIMIT 1';
         if ($this->DbType == 1) {
-            $SQL = 'SELECT "val" FROM *PREFIX*ocdownloader_'.$this->Table.' WHERE "key" = ?'
-                .(!is_null($this->UID) ? ' AND "uid" = ?' : '').' LIMIT 1';
+            $SQL = 'SELECT val FROM *PREFIX*ocdownloader_'.$this->Table.' WHERE key = ?'
+                .(!is_null($this->UID) ? ' AND uid = ?' : '').' LIMIT 1';
         }
         $Query = \OC_DB::prepare($SQL);
         if (!is_null($this->UID)) {
@@ -74,8 +74,8 @@ class Settings
         $SQL = 'SELECT `VAL` FROM `*PREFIX*ocdownloader_'.$this->Table.'` WHERE `KEY` = ?'
             .(!is_null($this->UID) ? ' AND `UID` = ?' : '').' LIMIT 1';
         if ($this->DbType == 1) {
-            $SQL = 'SELECT "val" FROM *PREFIX*ocdownloader_'.$this->Table.' WHERE "key" = ?'
-                .(!is_null($this->UID) ? ' AND "uid" = ?' : '').' LIMIT 1';
+            $SQL = 'SELECT val FROM *PREFIX*ocdownloader_'.$this->Table.' WHERE key = ?'
+                .(!is_null($this->UID) ? ' AND uid = ?' : '').' LIMIT 1';
         }
         $Query = \OC_DB::prepare($SQL);
 
@@ -96,8 +96,8 @@ class Settings
         $SQL = 'SELECT `KEY`, `VAL` FROM `*PREFIX*ocdownloader_'.$this->Table.'`'
             .(!is_null($this->UID) ? ' WHERE `UID` = ?' : '');
         if ($this->DbType == 1) {
-            $SQL = 'SELECT "key", "val" FROM *PREFIX*ocdownloader_'.$this->Table.''
-                .(!is_null($this->UID) ? ' WHERE "uid" = ?' : '');
+            $SQL = 'SELECT key, val FROM *PREFIX*ocdownloader_'.$this->Table.''
+                .(!is_null($this->UID) ? ' WHERE uid = ?' : '');
         }
         $Query = \OC_DB::prepare($SQL);
 
@@ -113,8 +113,8 @@ class Settings
         $SQL = 'UPDATE `*PREFIX*ocdownloader_' . $this->Table . '`SET `VAL` = ? WHERE `KEY` = ?'
             .(!is_null($this->UID) ? ' AND `UID` = ?' : '');
         if ($this->DbType == 1) {
-            $SQL = 'UPDATE *PREFIX*ocdownloader_' . $this->Table . 'SET "val" = ? WHERE "key" = ?'
-                .(!is_null($this->UID) ? ' AND "uid" = ?' : '');
+            $SQL = 'UPDATE *PREFIX*ocdownloader_' . $this->Table . ' SET val = ? WHERE key = ?'
+                .(!is_null($this->UID) ? ' AND uid = ?' : '');
         }
         $Query = \OC_DB::prepare($SQL);
 
@@ -130,8 +130,8 @@ class Settings
         $SQL = 'INSERT INTO `*PREFIX*ocdownloader_'.$this->Table.'`(`KEY`, `VAL`'
             .(!is_null($this->UID) ? ', `UID`' : '') . ') VALUES(?, ?' .(!is_null($this->UID) ? ', ?' : '').')';
         if ($this->DbType == 1) {
-            $SQL = 'INSERT INTO *PREFIX*ocdownloader_'.$this->Table.'("key", "val"'
-                .(!is_null($this->UID) ? ', "uid"' : '') . ') VALUES(?, ?' .(!is_null($this->UID) ? ', ?' : '').')';
+            $SQL = 'INSERT INTO *PREFIX*ocdownloader_'.$this->Table.'(key, val'
+                .(!is_null($this->UID) ? ', uid' : '') . ') VALUES(?, ?' .(!is_null($this->UID) ? ', ?' : '').')';
         }
         $Query = \OC_DB::prepare($SQL);
 

--- a/controller/lib/tools.php
+++ b/controller/lib/tools.php
@@ -134,12 +134,12 @@ class Tools
             .'(SELECT COUNT(*) FROM `*PREFIX*ocdownloader_queue` WHERE `STATUS` = ? AND `UID` = ?) as `STOPPED`,'
             .'(SELECT COUNT(*) FROM `*PREFIX*ocdownloader_queue` WHERE `STATUS` = ? AND `UID` = ?) as `REMOVED`';
         if ($DbType == 1) {
-            $SQL = 'SELECT(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" < ? AND "UID" = ?) as "ALL",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" = ? AND "UID" = ?) as "COMPLETES",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" = ? AND "UID" = ?) as "ACTIVES",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" = ? AND "UID" = ?) as "WAITINGS",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" = ? AND "UID" = ?) as "STOPPED",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE "STATUS" = ? AND "UID" = ?) as "REMOVED"';
+            $SQL = 'SELECT(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status < ? AND uid = ?) as "ALL",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "COMPLETES",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "ACTIVES",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "WAITINGS",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "STOPPED",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "REMOVED"';
         }
         $Query = \OC_DB::prepare($SQL);
         $Request = $Query->execute(array(5, $UID, 0, $UID, 1, $UID, 2, $UID, 3, $UID, 4, $UID));

--- a/controller/lib/tools.php
+++ b/controller/lib/tools.php
@@ -134,12 +134,12 @@ class Tools
             .'(SELECT COUNT(*) FROM `*PREFIX*ocdownloader_queue` WHERE `STATUS` = ? AND `UID` = ?) as `STOPPED`,'
             .'(SELECT COUNT(*) FROM `*PREFIX*ocdownloader_queue` WHERE `STATUS` = ? AND `UID` = ?) as `REMOVED`';
         if ($DbType == 1) {
-            $SQL = 'SELECT(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status < ? AND uid = ?) as "ALL",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "COMPLETES",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "ACTIVES",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "WAITINGS",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "STOPPED",'
-                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE status = ? AND uid = ?) as "REMOVED"';
+            $SQL = 'SELECT(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS < ? AND UID = ?) as "ALL",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS = ? AND UID = ?) as "COMPLETES",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS = ? AND UID = ?) as "ACTIVES",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS = ? AND UID = ?) as "WAITINGS",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS = ? AND UID = ?) as "STOPPED",'
+                .'(SELECT COUNT(*) FROM *PREFIX*ocdownloader_queue WHERE STATUS = ? AND UID = ?) as "REMOVED"';
         }
         $Query = \OC_DB::prepare($SQL);
         $Request = $Query->execute(array(5, $UID, 0, $UID, 1, $UID, 2, $UID, 3, $UID, 4, $UID));

--- a/controller/queue.php
+++ b/controller/queue.php
@@ -322,7 +322,7 @@ class Queue extends Controller
         header( 'Content-Type: application/json; charset=utf-8');
 
         try {
-            if ($this->WhichDownloader == 0) {
+            if (!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2') {
                 if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                     $Status = Aria2::tellStatus($_POST['GID']);
 
@@ -375,7 +375,7 @@ class Queue extends Controller
         header( 'Content-Type: application/json; charset=utf-8');
 
         try {
-            if ($this->WhichDownloader == 0) {
+            if (!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2') {
                 if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                     $Status = Aria2::tellStatus($_POST['GID']);
 
@@ -516,16 +516,16 @@ class Queue extends Controller
         try {
             if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                 $Status =(
-                $this->WhichDownloader == 0
+                !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                     ?Aria2::tellStatus($_POST['GID'])
                     :CURL::tellStatus($_POST['GID'])
                 );
 
                 $Remove['result'] = $_POST['GID'];
-                if (!isset($Status['error']) && strcmp($Status['result']['status'], 'error') != 0
+                if (!isset($Status['error']) && isset($Status['result']['status']) && strcmp($Status['result']['status'], 'error') != 0
                     && strcmp($Status['result']['status'], 'complete') != 0) {
                     $Remove =(
-                    $this->WhichDownloader == 0
+                    !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                         ? Aria2::remove($_POST['GID'])
                         :CURL::remove($Status['result'])
                     );
@@ -583,12 +583,12 @@ class Queue extends Controller
                 $GIDS = array();
 
                 foreach ($_POST['GIDS'] as $GID) {
-                    $Status =($this->WhichDownloader == 0 ? Aria2::tellStatus($GID) : CURL::tellStatus($GID));
+                    $Status =(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2' ? Aria2::tellStatus($GID) : CURL::tellStatus($GID));
                     $Remove = array('result' => $GID);
 
                     if (!isset($Status['error']) && strcmp($Status['result']['status'], 'error') != 0
                         && strcmp($Status['result']['status'], 'complete') != 0) {
-                        $Remove =($this->WhichDownloader == 0 ? Aria2::remove($GID) : CURL::remove($Status['result']));
+                        $Remove =(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2' ? Aria2::remove($GID) : CURL::remove($Status['result']));
                     }
 
                     if (!is_null($Remove) && strcmp($Remove['result'], $GID) == 0) {
@@ -641,14 +641,14 @@ class Queue extends Controller
         try {
             if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                 $Status =(
-                $this->WhichDownloader == 0
+                !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                     ?Aria2::tellStatus($_POST['GID'])
                     :CURL::tellStatus($_POST['GID'])
                 );
 
                 if (!isset($Status['error']) && strcmp($Status['result']['status'], 'removed') == 0) {
                     $Remove =(
-                    $this->WhichDownloader == 0
+                    !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                         ? Aria2::removeDownloadResult($_POST['GID'])
                         :CURL::removeDownloadResult($_POST['GID'])
                     );
@@ -692,11 +692,11 @@ class Queue extends Controller
                 $GIDS = array();
 
                 foreach ($_POST['GIDS'] as $GID) {
-                    $Status =($this->WhichDownloader == 0 ? Aria2::tellStatus($GID) : CURL::tellStatus($GID));
+                    $Status =(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2' ? Aria2::tellStatus($GID) : CURL::tellStatus($GID));
 
                     if (!isset($Status['error']) && strcmp($Status['result']['status'], 'removed') == 0) {
                         $Remove =(
-                        $this->WhichDownloader == 0
+                        !$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                             ?Aria2::removeDownloadResult($GID)
                             :CURL::removeDownloadResult($GID)
                         );

--- a/controller/queue.php
+++ b/controller/queue.php
@@ -128,8 +128,8 @@ class Queue extends Controller
                     . $StatusReq . ' AND `IS_CLEANED` IN ' . $IsCleanedReq . ' ORDER BY `TIMESTAMP` ASC';
 
                 if ($this->DbType == 1) {
-                    $SQL = 'SELECT * FROM *PREFIX*ocdownloader_queue WHERE "UID" = ? AND "STATUS" IN '
-                        . $StatusReq . ' AND "IS_CLEANED" IN ' . $IsCleanedReq . ' ORDER BY "TIMESTAMP" ASC';
+                    $SQL = 'SELECT * FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND status IN '
+                        . $StatusReq . ' AND is_cleaned IN ' . $IsCleanedReq . ' ORDER BY timestamp ASC';
                 }
                 $Query = \OC_DB::prepare($SQL);
                 $Request = $Query->execute($Params);
@@ -137,7 +137,8 @@ class Queue extends Controller
                 $Queue = [];
                 $DownloadUpdated = false;
                 while ($Row = $Request->fetchRow()) {
-                    $Status =($this->WhichDownloader == 0
+                    $Row = array_change_key_case($Row, CASE_UPPER);
+                    $Status =(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                         ?Aria2::tellStatus($Row['GID']):CURL::tellStatus($Row['GID']));
                     $DLStatus = 5; // Error
 
@@ -195,7 +196,7 @@ class Queue extends Controller
 						WHERE `UID` = ? AND `GID` = ?';
                                     if ($this->$DbType == 1) {
                                         $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue
-						WHERE "UID" = ? AND "GID" = ?';
+						WHERE uid = ? AND gid = ?';
                                     }
 
                                     $Query = \OC_DB::prepare($SQL);
@@ -211,7 +212,7 @@ class Queue extends Controller
 								 (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                                             if ($this->$DbType == 1) {
                                                 $addSQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-								("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP") VALUES(?, ?, ?, ?, ?, ?)';
+								(uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
                                             }
                                             $addQuery = \OC_DB::prepare($addSQL);
                                             $addQuery->execute(array(
@@ -230,7 +231,7 @@ class Queue extends Controller
 		                                    SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ? AND `STATUS` != ?';
                                     if ($this->DbType == 1) {
                                         $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-		                                        SET "STATUS" = ? WHERE "UID" = ? AND "GID" = ? AND "STATUS" != ?';
+		                                        SET status = ? WHERE uid = ? AND gid = ? AND status != ?';
                                     }
 
                                     $Query = \OC_DB::prepare($SQL);
@@ -335,7 +336,7 @@ class Queue extends Controller
                     if (strcmp($Pause['result'], $_POST['GID']) == 0) {
                         $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
-                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET "STATUS" = ? WHERE "UID" = ? AND "GID" = ?';
+                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET status = ? WHERE uid = ? AND gid = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -388,7 +389,7 @@ class Queue extends Controller
                     if (strcmp($UnPause['result'], $_POST['GID']) == 0) {
                         $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
-                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET "STATUS" = ? WHERE "UID" = ? AND "GID" = ?';
+                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET status = ? WHERE uid = ? AND gid = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -433,7 +434,7 @@ class Queue extends Controller
             if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                 $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                 if ($this->DbType == 1) {
-                    $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET "IS_CLEANED" = ? WHERE "UID" = ? AND "GID" = ?';
+                    $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET is_cleaned = ? WHERE uid = ? AND gid = ?';
                 }
 
                 $Query = \OC_DB::prepare($SQL);
@@ -469,7 +470,7 @@ class Queue extends Controller
                 foreach ($_POST['GIDS'] as $GID) {
                     $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
-                        $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET "IS_CLEANED" = ? WHERE "UID" = ? AND "GID" = ?';
+                        $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET is_cleaned = ? WHERE uid = ? AND gid = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);
@@ -537,7 +538,7 @@ class Queue extends Controller
                         SET `STATUS` = ?, `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
                         $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-                            SET "STATUS" = ?, "IS_CLEANED" = ? WHERE "UID" = ? AND "GID" = ?';
+                            SET status = ?, is_cleaned = ? WHERE uid = ? AND gid = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);
@@ -595,7 +596,7 @@ class Queue extends Controller
                             SET `STATUS` = ?, `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
                             $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-                                SET "STATUS" = ?, "IS_CLEANED" = ? WHERE "UID" = ? AND "GID" = ?';
+                                SET status = ?, is_cleaned = ? WHERE uid = ? AND gid = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -655,7 +656,7 @@ class Queue extends Controller
 
                 $SQL = 'DELETE FROM `*PREFIX*ocdownloader_queue` WHERE `UID` = ? AND `GID` = ?';
                 if ($this->DbType == 1) {
-                    $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE "UID" = ? AND "GID" = ?';
+                    $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND gid = ?';
                 }
 
                 $Query = \OC_DB::prepare($SQL);
@@ -703,7 +704,7 @@ class Queue extends Controller
 
                     $SQL = 'DELETE FROM `*PREFIX*ocdownloader_queue` WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
-                        $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE "UID" = ? AND "GID" = ?';
+                        $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND gid = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/queue.php
+++ b/controller/queue.php
@@ -128,8 +128,8 @@ class Queue extends Controller
                     . $StatusReq . ' AND `IS_CLEANED` IN ' . $IsCleanedReq . ' ORDER BY `TIMESTAMP` ASC';
 
                 if ($this->DbType == 1) {
-                    $SQL = 'SELECT * FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND status IN '
-                        . $StatusReq . ' AND is_cleaned IN ' . $IsCleanedReq . ' ORDER BY timestamp ASC';
+                    $SQL = 'SELECT * FROM *PREFIX*ocdownloader_queue WHERE UID = ? AND STATUS IN '
+                        . $StatusReq . ' AND IS_CLEANED IN ' . $IsCleanedReq . ' ORDER BY TIMESTAMP ASC';
                 }
                 $Query = \OC_DB::prepare($SQL);
                 $Request = $Query->execute($Params);
@@ -195,7 +195,7 @@ class Queue extends Controller
 						WHERE `UID` = ? AND `GID` = ?';
                                     if ($this->$DbType == 1) {
                                         $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue
-						WHERE uid = ? AND gid = ?';
+						WHERE UID = ? AND GID = ?';
                                     }
 
                                     $Query = \OC_DB::prepare($SQL);
@@ -211,7 +211,7 @@ class Queue extends Controller
 								 (`UID`, `GID`, `FILENAME`, `PROTOCOL`, `STATUS`, `TIMESTAMP`) VALUES(?, ?, ?, ?, ?, ?)';
                                             if ($this->$DbType == 1) {
                                                 $addSQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-								(uid, gid, filename, protocol, status, timestamp) VALUES(?, ?, ?, ?, ?, ?)';
+								(UID, GID, FILENAME, PROTOCOL, STATUS, TIMESTAMP) VALUES(?, ?, ?, ?, ?, ?)';
                                             }
                                             $addQuery = \OC_DB::prepare($addSQL);
                                             $addQuery->execute(array(
@@ -230,7 +230,7 @@ class Queue extends Controller
 		                                    SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ? AND `STATUS` != ?';
                                     if ($this->DbType == 1) {
                                         $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-		                                        SET status = ? WHERE uid = ? AND gid = ? AND status != ?';
+		                                        SET STATUS = ? WHERE UID = ? AND GID = ? AND STATUS != ?';
                                     }
 
                                     $Query = \OC_DB::prepare($SQL);
@@ -331,7 +331,7 @@ class Queue extends Controller
                     if (strcmp($Pause['result'], $_POST['GID']) == 0) {
                         $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
-                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET status = ? WHERE uid = ? AND gid = ?';
+                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET STATUS = ? WHERE UID = ? AND GID = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -384,7 +384,7 @@ class Queue extends Controller
                     if (strcmp($UnPause['result'], $_POST['GID']) == 0) {
                         $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `STATUS` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
-                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET status = ? WHERE uid = ? AND gid = ?';
+                            $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET STATUS = ? WHERE UID = ? AND GID = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -429,7 +429,7 @@ class Queue extends Controller
             if (isset($_POST['GID']) && strlen(trim($_POST['GID'])) > 0) {
                 $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                 if ($this->DbType == 1) {
-                    $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET is_cleaned = ? WHERE uid = ? AND gid = ?';
+                    $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET IS_CLEANED = ? WHERE UID = ? AND GID = ?';
                 }
 
                 $Query = \OC_DB::prepare($SQL);
@@ -465,7 +465,7 @@ class Queue extends Controller
                 foreach ($_POST['GIDS'] as $GID) {
                     $SQL = 'UPDATE `*PREFIX*ocdownloader_queue` SET `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
-                        $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET is_cleaned = ? WHERE uid = ? AND gid = ?';
+                        $SQL = 'UPDATE *PREFIX*ocdownloader_queue SET IS_CLEANED = ? WHERE UID = ? AND GID = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);
@@ -533,7 +533,7 @@ class Queue extends Controller
                         SET `STATUS` = ?, `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
                         $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-                            SET status = ?, is_cleaned = ? WHERE uid = ? AND gid = ?';
+                            SET STATUS = ?, IS_CLEANED = ? WHERE UID = ? AND GID = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);
@@ -591,7 +591,7 @@ class Queue extends Controller
                             SET `STATUS` = ?, `IS_CLEANED` = ? WHERE `UID` = ? AND `GID` = ?';
                         if ($this->DbType == 1) {
                             $SQL = 'UPDATE *PREFIX*ocdownloader_queue
-                                SET status = ?, is_cleaned = ? WHERE uid = ? AND gid = ?';
+                                SET STATUS = ?, IS_CLEANED = ? WHERE UID = ? AND GID = ?';
                         }
 
                         $Query = \OC_DB::prepare($SQL);
@@ -651,7 +651,7 @@ class Queue extends Controller
 
                 $SQL = 'DELETE FROM `*PREFIX*ocdownloader_queue` WHERE `UID` = ? AND `GID` = ?';
                 if ($this->DbType == 1) {
-                    $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND gid = ?';
+                    $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE UID = ? AND GID = ?';
                 }
 
                 $Query = \OC_DB::prepare($SQL);
@@ -699,7 +699,7 @@ class Queue extends Controller
 
                     $SQL = 'DELETE FROM `*PREFIX*ocdownloader_queue` WHERE `UID` = ? AND `GID` = ?';
                     if ($this->DbType == 1) {
-                        $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE uid = ? AND gid = ?';
+                        $SQL = 'DELETE FROM *PREFIX*ocdownloader_queue WHERE UID = ? AND GID = ?';
                     }
 
                     $Query = \OC_DB::prepare($SQL);

--- a/controller/ytdownloader.php
+++ b/controller/ytdownloader.php
@@ -189,7 +189,7 @@ class YTDownloader extends Controller
 
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                        (uid, gid, filename, protocol, status, timestamp)
+                        (UID, GID, FILENAME, PROTOCOL, STATUS, TIMESTAMP)
                         VALUES(?, ?, ?, ?, ?, ?)';
                     }
 

--- a/controller/ytdownloader.php
+++ b/controller/ytdownloader.php
@@ -211,33 +211,39 @@ class YTDownloader extends Controller
                     }
 
                     $Progress = 0;
-                    if ($Status['result']['totalLength'] > 0) {
+                    if (isset($Status['result']) && $Status['result']['totalLength'] > 0) {
                         $Progress = $Status['result']['completedLength'] / $Status['result']['totalLength'];
                     }
 
-                    $ProgressString = Tools::getProgressString(
-                        $Status['result']['completedLength'],
-                        $Status['result']['totalLength'],
-                        $Progress
-                    );
+                    if (isset($Status['result'])) {
+                        $ProgressString = Tools::getProgressString(
+                            $Status['result']['completedLength'],
+                            $Status['result']['totalLength'],
+                            $Progress
+                        );
+                    }
 
                     return new JSONResponse(array(
-                          'ERROR' => false,
-                          'MESSAGE' =>(string)$this->L10N->t('Download started'),
-                          'GID' => $AddURI['result'],
-                          'PROGRESSVAL' => round((($Progress) * 100), 2) . '%',
-                          'PROGRESS' => is_null($ProgressString) ?(string)$this->L10N->t('N/A') : $ProgressString,
-                          'STATUS' => isset($Status['result']['status'])
-                          ?(string)$this->L10N->t(ucfirst($Status['result']['status']))
-                          :(string)$this->L10N->t('N/A'),
-                          'STATUSID' => Tools::getDownloadStatusID($Status['result']['status']),
-                          'SPEED' => isset($Status['result']['downloadSpeed'])
-                          ?Tools::formatSizeUnits($Status['result']['downloadSpeed'])
-                          .'/s' :(string)$this->L10N->t('N/A'),
-                          'FILENAME' =>$DL['FILENAME'],
-                          'FILENAME_SHORT' => Tools::getShortFilename($DL['FILENAME']),
-                          'PROTO' => $DL['TYPE'],
-                          'ISTORRENT' => false
+                        'ERROR' => false,
+                        'MESSAGE' => (string)$this->L10N->t('Download started'),
+                        'GID' => $AddURI['result'],
+                        'PROGRESSVAL' => round((($Progress) * 100), 2) . '%',
+                        'PROGRESS' => empty($ProgressString)
+                            ? (string)$this->L10N->t('N/A')
+                            : $ProgressString,
+                        'STATUS' => isset($Status['result']['status'])
+                            ? (string)$this->L10N->t(ucfirst($Status['result']['status']))
+                            : (string)$this->L10N->t('N/A'),
+                        'STATUSID' => isset($Status['result']['status'])
+                            ? Tools::getDownloadStatusID($Status['result']['status'])
+                            : (string)$this->L10N->t('N/A'),
+                        'SPEED' => isset($Status['result']['downloadSpeed'])
+                            ? Tools::formatSizeUnits($Status['result']['downloadSpeed']) . '/s'
+                            : (string)$this->L10N->t('N/A'),
+                        'FILENAME' => $DL['FILENAME'],
+                        'FILENAME_SHORT' => Tools::getShortFilename($DL['FILENAME']),
+                        'PROTO' => $DL['TYPE'],
+                        'ISTORRENT' => false
                     ));
                 } else {
                     return new JSONResponse(array(

--- a/controller/ytdownloader.php
+++ b/controller/ytdownloader.php
@@ -178,7 +178,7 @@ class YTDownloader extends Controller
                     $OPTIONS['max-download-limit'] = $this->MaxDownloadSpeed . 'K';
                 }
 
-                $AddURI =($this->WhichDownloader == 0
+                $AddURI =(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2'
                 ?Aria2::addUri(array($DL['URL']), array('Params' => $OPTIONS))
                 :CURL::addUri($DL['URL'], $OPTIONS));
 
@@ -204,7 +204,11 @@ class YTDownloader extends Controller
                     ));
 
                     sleep(1);
-                    $Status = Aria2::tellStatus($AddURI['result']);
+                    if ($this->WhichDownloader == 'CURL') {
+                        $Status = CURL::tellStatus($AddURI['result']);
+                    } elseif(!$this->WhichDownloader || $this->WhichDownloader == 'AIRA2') {
+                        $Status = Aria2::tellStatus($AddURI['result']);
+                    }
 
                     $Progress = 0;
                     if ($Status['result']['totalLength'] > 0) {

--- a/controller/ytdownloader.php
+++ b/controller/ytdownloader.php
@@ -189,7 +189,7 @@ class YTDownloader extends Controller
 
                     if ($this->DbType == 1) {
                         $SQL = 'INSERT INTO *PREFIX*ocdownloader_queue
-                        ("UID", "GID", "FILENAME", "PROTOCOL", "STATUS", "TIMESTAMP")
+                        (uid, gid, filename, protocol, status, timestamp)
                         VALUES(?, ?, ?, ?, ?, ?)';
                     }
 


### PR DESCRIPTION
In PostgreSQL columns with double quote are interpreted literally.

I used Nextcloud 20.0.4, and when setup finished, all columns where created in lowercase.

To resolve this problem, I changed all columns to syntax without double quotes.

The WhichDownloader property was being used incorrectly when it was to be CURL. Adjustments were made to avoid errors.

I changed some places that were giving error for accessing array keys that didn't exist.