### PR TITLE
Bugfix : WhichDownloader typo

### DIFF
--- a/controller/queue.php
+++ b/controller/queue.php
@@ -200,7 +200,7 @@ class Queue extends Controller
                                 $followedBy = $Status["result"]["followedBy"];
 
                                 foreach ($followedBy as $followed) {
-                                    $followedStatus =($this->$WhichDownloader == 0?Aria2::tellStatus($followed):CURL::tellStatus($followed));
+                                    $followedStatus =($this->WhichDownloader == 0?Aria2::tellStatus($followed):CURL::tellStatus($followed));
                                     if (!isset($followedStatus['error'])) {
                                         // Check if GID already exists
 


### PR DESCRIPTION
Undefined variable reported in Nextcloud logs console.
`Error: Undefined variable: WhichDownloader at /var/www/nextcloud/apps/ocdownloader/controller/queue.php#203`

Seemed to be a simple typo
